### PR TITLE
P3-558: iOS 13 indexedDB compatability

### DIFF
--- a/src/ios/MigrateLocalStorage.m
+++ b/src/ios/MigrateLocalStorage.m
@@ -72,13 +72,18 @@
     NSString* appLibraryFolder = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) objectAtIndex:0];
     NSString* original;
 
-    if ([[NSFileManager defaultManager] fileExistsAtPath:[appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage/___IndexedDB/file__0"]]) {
-        original = [appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage"];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:[appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage/___IndexedDB/v1/file__0"]]) {
+        original = [appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage/___IndexedDB/v1"];
     } else {
-        original = [appLibraryFolder stringByAppendingPathComponent:@"Caches"];
+        if([[NSFileManager defaultManager] fileExistsAtPath:[appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage/___IndexedDB/file__0"]] ) {
+            original = [appLibraryFolder stringByAppendingPathComponent:@"WebKit/LocalStorage/___IndexedDB"];
+        } else {
+            // FIXME this is the wrong location for the cache
+            original = [appLibraryFolder stringByAppendingPathComponent:@"Caches"];
+        }
     }
 
-    original = [original stringByAppendingPathComponent:@"___IndexedDB/file__0"];
+    original = [original stringByAppendingPathComponent:@"file__0"];
 
     NSString* target = [[NSString alloc] initWithString: [appLibraryFolder stringByAppendingPathComponent:@"WebKit"]];
 
@@ -88,7 +93,11 @@
     target = [target stringByAppendingPathComponent:bundleIdentifier];
 #endif
 
-    target = [target stringByAppendingPathComponent:@"WebsiteData/IndexedDB/file__0"];
+    if ([[NSFileManager defaultManager] fileExistsAtPath:[appLibraryFolder stringByAppendingPathComponent:@"WebKit/WebsiteData/IndexedDB/v1"]]) {
+        target = [target  stringByAppendingPathComponent:@"WebsiteData/IndexedDB/v1/file__0"];
+    } else {
+        target = [target stringByAppendingPathComponent:@"WebsiteData/IndexedDB/v0/file__0"];
+    }
 
     // Only copy data if no existing indexed db data exists yet for wkwebview
     if (![[NSFileManager defaultManager] fileExistsAtPath:target]) {


### PR DESCRIPTION
*  iOS 13 has changed the locations of indexedDB with a legacy container
named v0 and an upgraded container named v1 (as of March 2019). Migrating
from UIWebView to WkWebview will now place indexedDB contents in v1 if
available and in v0 otherwise and let iOS 13 handle indexedDB upgrade
to v1.